### PR TITLE
COMP: Use vtkMRMLLabelMapVolumeNode

### DIFF
--- a/src/carreraslice_wrap/CarreraSliceEffect.py
+++ b/src/carreraslice_wrap/CarreraSliceEffect.py
@@ -312,7 +312,7 @@ def get_values_at_IJK( ijk, sliceWidget):
     if ijk[ele] < 0 or ijk[ele] >= dims[ele]:
       #print "Out of Frame"
       wasOutOfFrame=True
-  if not wasOutOfFrame and volumeNode.GetLabelMap():
+  if not wasOutOfFrame and volumeNode.IsA('vtkMRMLLabelMapVolumeNode'):
     labelIndex = int(imageData.GetScalarComponentAsDouble(ijk[0], ijk[1], ijk[2], 0))
     #print "labelIndex = " + str(labelIndex)
     values['label'] = labelIndex

--- a/src/carreraslice_wrap/Documentation/VolumeMasker.py
+++ b/src/carreraslice_wrap/Documentation/VolumeMasker.py
@@ -47,7 +47,6 @@ class VolumeMaskerWidget:
 
     self.inputVolumeSelector = slicer.qMRMLNodeComboBox(self.inputVolumeSelectorFrame)
     self.inputVolumeSelector.nodeTypes = ( ("vtkMRMLScalarVolumeNode"), "" )
-    self.inputVolumeSelector.addAttribute( "vtkMRMLScalarVolumeNode", "LabelMap", 0 )
     self.inputVolumeSelector.selectNodeUponCreation = False
     self.inputVolumeSelector.addEnabled = False
     self.inputVolumeSelector.removeEnabled = False
@@ -70,8 +69,7 @@ class VolumeMaskerWidget:
     self.labelSelectorFrame.layout().addWidget( self.labelSelectorLabel )
 
     self.labelSelector = slicer.qMRMLNodeComboBox()
-    self.labelSelector.nodeTypes = ( "vtkMRMLScalarVolumeNode", "" )
-    self.labelSelector.addAttribute( "vtkMRMLScalarVolumeNode", "LabelMap", "1" )
+    self.labelSelector.nodeTypes = ( "vtkMRMLLabelMapVolumeNode", "" )
     self.labelSelector.selectNodeUponCreation = False
     self.labelSelector.addEnabled = False
     self.labelSelector.noneEnabled = True


### PR DESCRIPTION
A new class for labelmap nodes (vtkMRMLLabelmapNode) was introduced into the Slicer core
that replaces the old method of storing segmentation in a vtkMRMLScalarVolumeNode with
a custom “labelmap” attribute set to "1".
See details here:
http://www.slicer.org/slicerWiki/index.php/Documentation/Labs/Segmentations#vtkMRMLLabelMapVolumeNode_integration

This change in the Slicer core requires modification of your extension. See the suggested change in this commit.